### PR TITLE
add issue comment github action workflow

### DIFF
--- a/.github/workflows/inform-system-team-new-issue.yaml
+++ b/.github/workflows/inform-system-team-new-issue.yaml
@@ -1,3 +1,22 @@
+#########################################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#########################################################################################
+
 name: inform sig-infra team about support issues
 on:
   issues:
@@ -13,6 +32,7 @@ jobs:
       issues: write
     steps:
       - name: Add comment
+        # MIT Licence from https://github.com/peter-evans/create-or-update-comment/blob/main/LICENSE
         uses: peter-evans/create-or-update-comment@v2.1.1
         with:
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/inform-system-team-new-issue.yaml
+++ b/.github/workflows/inform-system-team-new-issue.yaml
@@ -42,8 +42,3 @@ jobs:
             thanks for raising an issue to our System Team Support we will work on it and
             we will keep you up-to-date over this issue and feel free to communicate with us.
             One of our System Team will have a look at your issue and try to help you.
-            
-            Info to System-Team:
-            @SebastianBezold @carslen @almadigabor @hzierer @FaGru3n @Siegfriedk
-            > This support issue is available for anyone to work on. Please make sure to reference this issue in your pull request.
-            > Thank you for your contribution! :sparkles:

--- a/.github/workflows/inform-system-team-new-issue.yml
+++ b/.github/workflows/inform-system-team-new-issue.yml
@@ -18,4 +18,12 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           # Here you can add you personal style of comment messages and which GitHub-team should be informed
           body: |
-            Info: :wave: Hi @catenax-ng/argocdadmins, we got a new support issue on the [board](https://github.com/orgs/eclipse-tractusx/projects/9/views/1) and it is available for anyone to work on. Make sure to reference this issue in your pull request. Thank you for your contribution! 
+            Hello @${{ github.event.issue.user.login }} :wave:,
+            thanks for raising an issue to our System Team Support we will work on it and
+            we will keep you up-to-date over this issue and feel free to communicate with us.
+            One of our System Team will have a look at your issue and try to help you.
+            
+            Info to System-Team:
+            @SebastianBezold @carslen @almadigabor @hzierer @FaGru3n @Siegfriedk
+            > This support issue is available for anyone to work on. Please make sure to reference this issue in your pull request.
+            > Thank you for your contribution! :sparkles:

--- a/.github/workflows/inform-system-team-new-issue.yml
+++ b/.github/workflows/inform-system-team-new-issue.yml
@@ -1,11 +1,11 @@
-name: inform system-team about support issues
+name: inform sig-infra team about support issues
 on:
   issues:
     types:
       - opened
       - labeled
 jobs:
-  add-comment-to-inform-system-team:
+  add-issue-comment-to-inform-sig-infra:
     # based on the issue label write a comment to inform team
     if: github.event.label.name == 'support'
     runs-on: ubuntu-latest
@@ -16,6 +16,6 @@ jobs:
         uses: peter-evans/create-or-update-comment@v2.1.1
         with:
           issue-number: ${{ github.event.issue.number }}
-          # Here you can add you personal style of comment messages and which gh-team should be informed
+          # Here you can add you personal style of comment messages and which GitHub-team should be informed
           body: |
             Info: :wave: Hi @catenax-ng/argocdadmins, we got a new support issue on the [board](https://github.com/orgs/eclipse-tractusx/projects/9/views/1) and it is available for anyone to work on. Make sure to reference this issue in your pull request. Thank you for your contribution! 

--- a/.github/workflows/inform-system-team-new-issue.yml
+++ b/.github/workflows/inform-system-team-new-issue.yml
@@ -1,0 +1,21 @@
+name: inform system-team about support issues
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+jobs:
+  add-comment-to-inform-system-team:
+    # based on the issue label write a comment to inform team
+    if: github.event.label.name == 'support'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@v2.1.1
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          # Here you can add you personal style of comment messages and which gh-team should be informed
+          body: |
+            Info: :wave: Hi @catenax-ng/argocdadmins, we got a new support issue on the [board](https://github.com/orgs/eclipse-tractusx/projects/9/views/1) and it is available for anyone to work on. Make sure to reference this issue in your pull request. Thank you for your contribution! 


### PR DESCRIPTION
- add workflow file with an gh-action to perform issue comments on new created issues to inform catena-x-gh-teams members about this new issue.
- based on the personal user prefered notification rule for the @mentioning parts you will recive a GitHub Notification or a Email that you were mentioned in this comment

Added public GitHub action:
https://github.com/marketplace/actions/create-or-update-comment

At the moment within Eclipse Tractus-X GitHub Organisaition there will be no 
> create and maintain custom tailored GitHub teams.

At this point its just a check if you can reference diffrent organisation GitHub teams to be notified.