### PR TITLE
chore: add system-team-task.md as issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/system-team-task.md
+++ b/.github/ISSUE_TEMPLATE/system-team-task.md
@@ -15,4 +15,4 @@ assignees: ''
 - <!-- ToDo -->
 
 **Additional information / links**
-<!-- Here you add specific information -->
+<!-- Here you can add specific information -->

--- a/.github/ISSUE_TEMPLATE/system-team-task.md
+++ b/.github/ISSUE_TEMPLATE/system-team-task.md
@@ -2,7 +2,7 @@
 name: 'System Team Task'
 about: Generate Tasks for the System Team
 title: ''
-labels: task
+labels: tasks
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/system-team-task.md
+++ b/.github/ISSUE_TEMPLATE/system-team-task.md
@@ -1,0 +1,18 @@
+---
+name: 'System Team Task'
+about: Generate Tasks for the System Team
+title: ''
+labels: task
+assignees: ''
+
+---
+
+**Reason**
+<!-- Here you can describe why and what we need to do -->
+
+**AC**
+- <!-- What acceptance criteria need to be fulfilled to close this issue -->
+- <!-- ToDo -->
+
+**Additional information / links**
+<!-- Here you add specific information -->


### PR DESCRIPTION
### Description
#### What you changed / added?
- add annother issue template for task generation within our system-team
#### Why?
- first starting point to be able to generate our own tasks we want to do for the system-team
#### Testing
- add this .md in a `.github/ISSUE_TEMPLATES` folder in your "testing"-repository
#### Additional information
added an issue_label `tasks` within our sig-infra repo to separate support / security tasks from our tasks we want to develop
should look like this example:
![image](https://github.com/eclipse-tractusx/sig-infra/assets/121097161/8fa91751-d58c-489f-a110-3f011ce81836)

