### PR TITLE
chore: modify naming of consortia and add links to EF Gitlab issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Eclipse Matrix Communication Channels
-    url: https://chat.eclipse.org/#/room/#tools.tractus-x:matrix.eclipse.org
-    about: Committer Channel from Eclipse
+  - name: Eclipse Tractus X GitHub organisation Requests
+    url: https://eclipse-tractusx.github.io/docs/oss/issues#eclipse-foundation-helpdesk
+    about: If you need something for Eclipse Tractus X GitHub organisation we have to raise a GitLab Issue

--- a/.github/ISSUE_TEMPLATE/security-support-request.md
+++ b/.github/ISSUE_TEMPLATE/security-support-request.md
@@ -1,5 +1,5 @@
 ---
-name: 'Security General Request'
+name: 'Security: General Request'
 about: If you have a Security Request
 title: ''
 labels: security

--- a/.github/ISSUE_TEMPLATE/support-create-a-new-environment.md
+++ b/.github/ISSUE_TEMPLATE/support-create-a-new-environment.md
@@ -12,6 +12,6 @@ Requested by: <!-- Please add your Product_Owner_GitHub-User-ID -->
 End date of demonstration: <!-- Declare the end Date in format dd.mm.yyyy -->  
 Teams participating: <!-- Please fill in the product_team_name -->
 
-> BEWARE: 
+> ! Please be aware:   
 > We do not provide dedicated environments for single teams. We will provide a DEV, INT, and 
-PRE-PROD environment and teams will collectively use these environments together. A list of available environments can be found in the X Conf.
+PRE-PROD environment and teams will collectively use these environments together. A list of available environments can be found in the Catena-X Confluence.

--- a/.github/ISSUE_TEMPLATE/support-create-a-new-fork.md
+++ b/.github/ISSUE_TEMPLATE/support-create-a-new-fork.md
@@ -1,5 +1,5 @@
 ---
-name: 'Support: Create a new Fork in the consortium GitHub organisation'
+name: 'Support: Create a new Fork in the Catena-X organisation'
 about: If you need a new fork from Tractus-X into Catena-X NG
 title: 'GitHub: New fork '
 labels: support

--- a/.github/ISSUE_TEMPLATE/support-create-a-new-github-repository.md
+++ b/.github/ISSUE_TEMPLATE/support-create-a-new-github-repository.md
@@ -1,5 +1,5 @@
 ---
-name: 'Support: Create a new GitHub repository in the consortium GitHub organisation'
+name: 'Support: Create a new GitHub repository in the Catena-X organisation'
 about: If you need a new repository within Catena-X NG
 title: 'GitHub: New repository '
 labels: support

--- a/.github/ISSUE_TEMPLATE/support-create-a-new-github-team.md
+++ b/.github/ISSUE_TEMPLATE/support-create-a-new-github-team.md
@@ -1,5 +1,5 @@
 ---
-name: 'Support: Create a new GitHub Team in the consortium GitHub organisation'
+name: 'Support: Create a new GitHub Team in the Catena-X organisation'
 about: If you need a new team within Catena-X NG
 title: 'GitHub: New Team '
 labels: support

--- a/.github/ISSUE_TEMPLATE/support-invite-member-to-github-org.md
+++ b/.github/ISSUE_TEMPLATE/support-invite-member-to-github-org.md
@@ -1,5 +1,5 @@
 ---
-name: 'Support: Invite member to consortium GitHub organization'
+name: 'Support: Invite member to Catena-X organization'
 about: If you need to invite a new Member within Catena-X NG
 title: 'GitHub: Invite member '
 labels: support
@@ -7,9 +7,12 @@ assignees: ''
 
 ---
 
-new GitHub user: <!-- Please fill in the GITHUB-USER-ID -->
+Who should invited to [Catena-X NG](https://github.com/catenax-ng)
 
-Question from us: 
-<!-- who can verify that the new user is a Member of Catena-X NG GitHub Organisation -->
+GitHub User:
+<!-- Please fill in the GITHUB-USER-ID -->
 
-Vouching person: <!-- Please fill in your Product_Owner -->
+Vouching person: <!-- Please fill in your Product Owners GITHUB-USER-ID-->
+<!-- Info: Who can verify that the new user is a Member of Catena-X -->
+
+

--- a/.github/ISSUE_TEMPLATE/support-onboard-a-new-product.md
+++ b/.github/ISSUE_TEMPLATE/support-onboard-a-new-product.md
@@ -1,5 +1,5 @@
 ---
-name: 'Support: Onboard a new product in the consortium GitHub organisation'
+name: 'Support: Onboard a new product in the Catena-X GitHub organisation'
 about: If you need a complete new product within Catena-X NG
 title: 'New Product '
 labels: support


### PR DESCRIPTION
### Description of this Pull Request
#### What would be changed or will be added with this PR?
- modify the naming "consorium" as Catena-X GitHub organisation
- add a link to [EF Issue Tracker](https://eclipse-tractusx.github.io/docs/oss/issues#eclipse-foundation-helpdesk) documentation
- remove Matrix Channel Link
- modify "New Cantena-X Github User" with required information without email-adresses
- write down where to find our current environments
#### Why do i want to change this?
- to make it clear where to raise issues for what and which organisation
#### Additional information
Link should look like:
![image](https://github.com/eclipse-tractusx/sig-infra/assets/121097161/75a5fdf8-2bdd-480c-98a8-e542c3a2bf53)

