### PR TITLE
chore: add responsible vouching person gh-teams maintainer

### DIFF
--- a/.github/ISSUE_TEMPLATE/support-invite-member-to-github-org.md
+++ b/.github/ISSUE_TEMPLATE/support-invite-member-to-github-org.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Who should invited to [Catena-X NG](https://github.com/catenax-ng)
+Who should be invited to [Catena-X NG](https://github.com/catenax-ng)
 
 GitHub User:
 <!-- Please fill in the GITHUB-USER-ID -->

--- a/.github/ISSUE_TEMPLATE/support-invite-member-to-github-org.md
+++ b/.github/ISSUE_TEMPLATE/support-invite-member-to-github-org.md
@@ -1,18 +1,18 @@
 ---
 name: 'Support: Invite member to Catena-X organization'
-about: If you need to invite a new Member within Catena-X NG
+about: If you need to invite a new Member within Catena-X ng
 title: 'GitHub: Invite member '
 labels: support
 assignees: ''
 
 ---
 
-Who should be invited to [Catena-X NG](https://github.com/catenax-ng)
+Who should be invited to [Catena-X ng](https://github.com/catenax-ng)
 
 GitHub User:
 <!-- Please fill in the GITHUB-USER-ID -->
 
-Vouching person: <!-- Please fill in your Catena-X NG GitHub-Teams Maintainer GITHUB-USER-ID or the Product Owners GITHUB-USER-ID -->
+Vouching person: <!-- Please fill in your Catena-X ng GitHub-Teams Maintainer GITHUB-USER-ID or the Product Owners GITHUB-USER-ID -->
 <!-- Info: Who can verify that the new user is a Member of Catena-X -->
 
 

--- a/.github/ISSUE_TEMPLATE/support-invite-member-to-github-org.md
+++ b/.github/ISSUE_TEMPLATE/support-invite-member-to-github-org.md
@@ -12,7 +12,7 @@ Who should invited to [Catena-X NG](https://github.com/catenax-ng)
 GitHub User:
 <!-- Please fill in the GITHUB-USER-ID -->
 
-Vouching person: <!-- Please fill in your GitHub-Teams Maintainer GITHUB-USER-ID or the Product Owners GITHUB-USER-ID -->
+Vouching person: <!-- Please fill in your Catena-X NG GitHub-Teams Maintainer GITHUB-USER-ID or the Product Owners GITHUB-USER-ID -->
 <!-- Info: Who can verify that the new user is a Member of Catena-X -->
 
 

--- a/.github/ISSUE_TEMPLATE/support-invite-member-to-github-org.md
+++ b/.github/ISSUE_TEMPLATE/support-invite-member-to-github-org.md
@@ -12,7 +12,7 @@ Who should invited to [Catena-X NG](https://github.com/catenax-ng)
 GitHub User:
 <!-- Please fill in the GITHUB-USER-ID -->
 
-Vouching person: <!-- Please fill in your Product Owners GITHUB-USER-ID-->
+Vouching person: <!-- Please fill in your GitHub-Teams Maintainer GITHUB-USER-ID or the Product Owners GITHUB-USER-ID -->
 <!-- Info: Who can verify that the new user is a Member of Catena-X -->
 
 


### PR DESCRIPTION
### Description of this Pull Request
#### What would be change or will be added with this PR?
- add gh-teams maintainer as possible vouching person
#### Why do i want to change this?
- verification of new Members of Catena-X GitHub Organisation is unclear
#### Additional information
result from https://github.com/eclipse-tractusx/sig-infra/discussions/28