### PR TITLE
feat(builds): add reusable workflow to run quality checks

### DIFF
--- a/.github/workflows/reusable-quality-checks.yaml
+++ b/.github/workflows/reusable-quality-checks.yaml
@@ -1,0 +1,33 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+
+name: "Quality Checks (Release Guidelines)"
+
+on:
+  workflow_call:
+
+jobs:
+  check-quality:
+    name: Check quality guidelines
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run quality checks
+        uses: eclipse-tractusx/tractusx-quality-checks@v0.2

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
 # SIG infra
 
 This is the home of Eclipse Tractus-X Special Interest Group (SIG) infra.
+
+## Workflows
+
+This repository contains reusable workflows for the [eclipse-tractusx](https://github.com/eclipse-tractusx) GitHub
+organization. Their intent is to make the adoption of Eclipse Tractus-X processes and guidelines easier.
+
+See the [official documentation](https://docs.github.com/en/actions/using-workflows/reusing-workflows) on reusable workflows and specifically the part about
+[calling reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow)
+for further information. The following sections describe the reusable workflows provided in this repository and also show
+examples on how to use them.
+
+### Quality checks
+
+__Description__:    This workflow runs automated checks, that test for compliance with our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
+__Workflow file__:  [.github/workflows/quality-checks.yaml](.github/workflows/quality-checks.yaml)
+__Usage__:
+```yaml
+# Example .github/workflows/quality-checks.yaml in your repo
+name: "Quality Checks (Release Guidelines)"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-quality:
+    name: Run quality checks
+    runs-on: ubuntu-latest
+    steps:
+      # Reference the reusable workflow by <org>/<repo>/<path-to-reusable-workflow>@revision
+      # We recooment to use the @main branch, since we regularly maintain the quality checks (adding new, enhancing existing) 
+      - uses: eclipse-tractusx/sig-infra/.github/workflows/reusable-quality-checks.yaml@main
+```


### PR DESCRIPTION
## Description

This PR introduces a new reusable workflow to run quality checks. This initial version is doing a checkout and then calling our [tractusx-quality-checks](https://github.com/eclipse-tractusx/tractusx-quality-checks) action.
Future improvements might add more steps, that check for quality and compliance

Closes eclipse-tractusx/sig-infra#129

## Pre-review checks

- [x] Copyright and license header are present on all affected files

