### PR TITLE
Report vulnerabilities as advisories first

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,7 @@
 **Please do not report security vulnerabilities through public GitHub issues.**
 
 Please report vulnerabilities to this repository via GitHub security advisories instead.
+How? Inside affected repository --> security tab --> advisories --> _New draft security advisory_
 
 In severe cases, you can also report a found vulnerability here:
 [https://www.eclipse.org/security/](https://www.eclipse.org/security/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,5 +2,9 @@
 
 ## Reporting a Vulnerability
 
-Please report a found vulnerability here:
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Please report them to this repository via GitHub security advisories instead.
+
+In severe cases, you can also report a found vulnerability here:
 [https://www.eclipse.org/security/](https://www.eclipse.org/security/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Please report them to this repository via GitHub security advisories instead.
+Please report vulnerabilities to this repository via GitHub security advisories instead.
 
 In severe cases, you can also report a found vulnerability here:
 [https://www.eclipse.org/security/](https://www.eclipse.org/security/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,7 @@
 **Please do not report security vulnerabilities through public GitHub issues.**
 
 Please report vulnerabilities to this repository via GitHub security advisories instead.
+
 How? Inside affected repository --> security tab --> advisories --> _New draft security advisory_
 
 In severe cases, you can also report a found vulnerability here:


### PR DESCRIPTION
Report vulnerabilities as GitHub security advisories first.
In severe cases report to the Eclipse security board.
This procedure is agreed with the Eclipse security team.