### PR TITLE
docs(dependencies-check): add example workflows for yarn and dotnet

### DIFF
--- a/.github/workflows/reusable-dependencies-dotnet.yaml
+++ b/.github/workflows/reusable-dependencies-dotnet.yaml
@@ -1,0 +1,94 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+
+name: Check Dependencies (dotnet)
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  check-dependencies:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: ['6.0']
+
+    steps:
+  
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: dotnet restore src
+
+      - name: List packages
+        run: dotnet list src package --include-transitive --interactive | grep ">" | grep -Pv "\s(Org|Microsoft|NuGet|System|runtime|docker|Docker|NETStandard)" | sed -E -e "s/\s+> ([a-zA-Z\.\-]+).+\s([0-9]+\.[0-9]+\.[0-9]+)\s*/nuget\/nuget\/\-\/\1\/\2/g" | awk '!seen[$0]++' > PACKAGES
+
+      # For this step to work, you need to provide the executable of dash tool in the './scripts/download' directory (make sure to regularly update the executable)
+      - name: Generate Dependencies file
+        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.0.2.jar PACKAGES -project automotive.tractusx -summary DEPENDENCIES || true
+
+      - name: Check if dependencies were changed
+        id: dependencies-changed
+        run: |
+          changed=$(git diff DEPENDENCIES)
+          if [[ -n "$changed" ]]; then
+            echo "dependencies changed"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "dependencies not changed"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for restricted dependencies
+        run: |
+          restricted=$(grep ' restricted,' DEPENDENCIES || true)
+          if [[ -n "$restricted" ]]; then
+            echo "The following dependencies are restricted: $restricted"
+            exit 1
+          fi
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Upload DEPENDENCIES file
+        uses: actions/upload-artifact@v3
+        with:
+          path: DEPENDENCIES
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Signal need to update DEPENDENCIES
+        run: |
+          echo "Dependencies need to be updated (updated DEPENDENCIES file has been uploaded to workflow run)"
+          exit 1
+        if: steps.dependencies-changed.outputs.changed == 'true'

--- a/.github/workflows/reusable-dependencies-dotnet.yaml
+++ b/.github/workflows/reusable-dependencies-dotnet.yaml
@@ -20,11 +20,11 @@
 name: Check Dependencies (dotnet)
 
 on:
-  push:
-    branches: [main, dev]
-  pull_request:
-    types: [opened, synchronize, reopened]
-  workflow_dispatch:
+  # push:
+  #   branches: [main, dev]
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
+  # workflow_dispatch:
 
 jobs:
   check-dependencies:

--- a/.github/workflows/reusable-dependencies-yarn.yaml
+++ b/.github/workflows/reusable-dependencies-yarn.yaml
@@ -20,11 +20,11 @@
 name: Check Dependencies (yarn)
 
 on:
-  push:
-    branches: [main, dev]
-  pull_request:
-    types: [opened, synchronize, reopened]
-  workflow_dispatch:
+  # push:
+  #   branches: [main, dev]
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
+  # workflow_dispatch:
 
 jobs:
   check-dependencies:

--- a/.github/workflows/reusable-dependencies-yarn.yaml
+++ b/.github/workflows/reusable-dependencies-yarn.yaml
@@ -1,0 +1,80 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+
+name: Check Dependencies (yarn)
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  check-dependencies:
+
+    runs-on: ubuntu-latest
+
+    steps:
+  
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # For this step to work, you need to provide the executable of dash tool in the './scripts/download' directory (make sure to regularly update the executable)
+      - name: Generate Dependencies file
+        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.0.2.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES || true
+
+      - name: Check if dependencies were changed
+        id: dependencies-changed
+        run: |
+          changed=$(git diff DEPENDENCIES)
+          if [[ -n "$changed" ]]; then
+            echo "dependencies changed"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "dependencies not changed"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for restricted dependencies
+        run: |
+          restricted=$(grep ' restricted,' DEPENDENCIES || true)
+          if [[ -n "$restricted" ]]; then
+            echo "The following dependencies are restricted: $restricted"
+            exit 1
+          fi
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Upload DEPENDENCIES file
+        uses: actions/upload-artifact@v3
+        with:
+          path: DEPENDENCIES
+        if: steps.dependencies-changed.outputs.changed == 'true'
+
+      - name: Signal need to update DEPENDENCIES
+        run: |
+          echo "Dependencies need to be updated (updated DEPENDENCIES file has been uploaded to workflow run)"
+          exit 1
+        if: steps.dependencies-changed.outputs.changed == 'true'


### PR DESCRIPTION
---
Add example workflows to check dependencies for yarn and dotnet
---

## Description

- add example workflows to check dependencies for yarn and dotnet

the workflows also provides a quite easy option to update the DEPENDENCIES file (without committing on the feature branch via bot or opening another PR, I didn't like both options): once all the previous step were successful so that no restricted dependencies are in the DEPENDENCIES file anymore, the last step uploads the updated DEPENDENCIES file to the workflow as downloadable artifact which can then be easily committed.

## Why
enhancing documentation and share knowledge across project
