### PR TITLE
feat: add static files workflows and update README.md

### DIFF
--- a/.github/workflows/reusable-generate-mermaid-svg.yaml
+++ b/.github/workflows/reusable-generate-mermaid-svg.yaml
@@ -73,6 +73,6 @@ jobs:
       - uses: actions/upload-artifact@v3
         # upload generated files as Job artifacts which can be downloaded in the in your caller workflow
         with:
-          name: my-svg-artifacts
+          name: artifacts
           path: "**/*.svg"
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`

--- a/.github/workflows/reusable-generate-mermaid-svg.yaml
+++ b/.github/workflows/reusable-generate-mermaid-svg.yaml
@@ -1,0 +1,78 @@
+#########################################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#########################################################################################
+
+name: 'generate static Mermaid files'
+on:
+  workflow_call:
+    inputs:
+      mmdc_version:
+        required: true
+        default: 10.2.4
+        type: string
+      node_version:
+        required: true
+        default: 16
+        type: string
+    outputs:
+      found_files:
+        description: "Information which mermaid files are found in step"
+        value: ${{ jobs.generate-mermaid-files.outputs.mermaid_files }}
+      files:
+        description: "Information which mermaid files will be generated"
+        value: ${{ jobs.generate-mermaid-files.outputs.generated_files }}
+
+jobs:
+  generate-mermaid-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node_version }}
+      - name: install mermaid cli
+        # https://www.npmjs.com/package/@mermaid-js/mermaid-cli
+        run: |
+          npm install -g @mermaid-js/mermaid-cli@${{ inputs.mmdc_version.value }}
+      - name: print mmdc version
+        run: |
+          mmdc -V
+      - name: checkout source repo
+        uses: actions/checkout@v3
+      - name: search for files
+        id: search_files
+        run: |
+          pwd
+          echo "mermaid_files=$(find . -type f \( -name "*.mmd" -o -name "*.mermaid" \) | xargs )" >> $GITHUB_OUTPUT
+      - name: show step output
+        run: echo "step files from ${{ steps.search_files.outputs.mermaid_files }}"
+      - name: generate svg file
+        id: generate
+        run: |
+          for file in ${{ steps.search_files.outputs.mermaid_files }};
+            do
+             mmdc -i $file -o ${file%.*}.svg
+             echo "${file%.*}.svg"
+             echo "generated_files=${file%.*}.svg" >> $GITHUB_OUTPUT
+            done
+      - uses: actions/upload-artifact@v3
+        # upload generated files as Job artifacts which can be downloaded in the in your caller workflow
+        with:
+          name: my-svg-artifacts
+          path: "**/*.svg"
+          if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`

--- a/.github/workflows/reusable-generate-puml-svg.yaml
+++ b/.github/workflows/reusable-generate-puml-svg.yaml
@@ -45,6 +45,6 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: my-puml-artifacts
+          name: artifacts
           path: "**/*.svg"
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`

--- a/.github/workflows/reusable-generate-puml-svg.yaml
+++ b/.github/workflows/reusable-generate-puml-svg.yaml
@@ -1,0 +1,50 @@
+#########################################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#########################################################################################
+
+name: generate static PlantUML files
+on:
+  workflow_call:
+    # workflow outputs to generate-files job outputs
+    outputs:
+      puml-files:
+        description: "generated puml files"
+        value: ${{ jobs.generate-files.outputs.puml_files }}
+
+jobs:
+  generate-files:
+    runs-on: ubuntu-latest
+    # Map the job outputs to step outputs
+    outputs:
+      puml-files: ${{ steps.generate.generate.puml_files }}
+    steps:
+      - name: checkout source repo
+        uses: actions/checkout@v3
+
+      - name: Generate PlantUML Diagrams
+        id: generate
+        uses: rotaract/plantuml-action@v1.3.0
+        with:
+          format: svg
+          pattern: "**/*.puml"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: my-puml-artifacts
+          path: "**/*.svg"
+          if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`

--- a/README.md
+++ b/README.md
@@ -38,6 +38,86 @@ jobs:
       # We recooment to use the @main branch, since we regularly maintain the quality checks (adding new, enhancing existing) 
       - uses: eclipse-tractusx/sig-infra/.github/workflows/reusable-quality-checks.yaml@main
 ```
+### Generate static PlantUML files
+
+__Description__: This workflow generates static .svg files from your repository .puml-files and upload this as job artifact
+
+__Workflow file__:  [.github/workflows/reusable-generate-puml-svg.yaml](.github/workflows/reusable-generate-puml-svg.yaml)
+
+__Usage__:
+```yaml
+# Example .github/workflows/add-static-puml-files.yaml in your repo
+name: "Render static puml files"
+# Trigger as you want here in example each time a PlantUML file was updated on main branch
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '**/*.puml'
+jobs:
+  render-images:
+    uses: eclipse-tractusx/sig-infra/.github/workflows/reusable-generate-puml-svg.yml@main
+
+  store-images:
+    runs-on: ubuntu-latest
+    # 2nd job needs to wait for first job to finish 
+    needs: render-images
+    steps:
+      - name: checkout source repo
+        uses: actions/checkout@v3
+      - name: download generated svg file from job before
+        uses: actions/download-artifact@v3
+        id: download
+        with:
+          name: my-puml-artifacts
+          path: ${{ github.workspace }}
+      # now you can handle the files in your desired way
+```
+
+### Generate static Mermaid files
+
+__Description__: This workflow generates static .svg files from your repository .mmd/.mermaid-files and upload this as job artifact
+
+__Workflow file__:  [.github/workflows/reusable-generate-mermaid-svg.yaml](.github/workflows/reusable-generate-mermaid-svg.yaml)
+
+__Usage__:
+```yaml
+# Example .github/workflows/add-static-mermaid-files.yml in your repo
+name: "Render static mermaid files"
+# Trigger as you want here in example each time a mermaid file was updated on main branch
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '**/*.mermaid'
+      - '**/*.mmd'
+jobs:
+  render-images:
+    # Uses our workflow with specified mermaid-cli and node version
+    uses: eclipse-tractusx/sig-infra/.github/workflows/reusable-generate-mermaid-svg.yml@main
+    with:
+      node_version: 16
+      mmdc_version: 10.2.4
+
+  store-images:
+    runs-on: ubuntu-latest
+    needs: render-images
+    steps:
+      - name: checkout source repo
+        uses: actions/checkout@v3
+
+      - name: download generated svg file from job before
+        # here you downlowd the generated files from previous job
+        uses: actions/download-artifact@v3
+        id: download
+        with:
+          name: my-svg-artifacts
+          # choose where to store this file
+          path: ${{ github.workspace }}
+      # now you can handle the files in your desired way
+```
 
 ## Actions
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ jobs:
         uses: actions/download-artifact@v3
         id: download
         with:
-          name: my-puml-artifacts
+          name: artifacts
           path: ${{ github.workspace }}
       # now you can handle the files in your desired way
 ```
@@ -113,7 +113,7 @@ jobs:
         uses: actions/download-artifact@v3
         id: download
         with:
-          name: my-svg-artifacts
+          name: artifacts
           # choose where to store this file
           path: ${{ github.workspace }}
       # now you can handle the files in your desired way


### PR DESCRIPTION
### Changes

- add a workflow `reusable-generate-mermaid-svg.yml`  to generate `.svg`-files from found mermaid files
- add a workflow `reusable-generate-puml-svg.yml` to generate `.svg`-files from found plantuml files
- add example workflow files for each workflow in `ReadMe.md`

### Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:


- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files
