### PR TITLE
fix(workflows): add workflow_call trigger so they don't run

### DIFF
--- a/.github/workflows/reusable-dependencies-dotnet.yaml
+++ b/.github/workflows/reusable-dependencies-dotnet.yaml
@@ -20,11 +20,7 @@
 name: Check Dependencies (dotnet)
 
 on:
-  # push:
-  #   branches: [main, dev]
-  # pull_request:
-  #   types: [opened, synchronize, reopened]
-  # workflow_dispatch:
+  workflow_call:
 
 jobs:
   check-dependencies:
@@ -35,7 +31,7 @@ jobs:
         dotnet-version: ['6.0']
 
     steps:
-  
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/reusable-dependencies-yarn.yaml
+++ b/.github/workflows/reusable-dependencies-yarn.yaml
@@ -20,11 +20,7 @@
 name: Check Dependencies (yarn)
 
 on:
-  # push:
-  #   branches: [main, dev]
-  # pull_request:
-  #   types: [opened, synchronize, reopened]
-  # workflow_dispatch:
+  workflow_call:
 
 jobs:
   check-dependencies:
@@ -32,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-  
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
## Description

Adds a `on: workflow_call` trigger to the reusable .NET and yarn dependency workflows to prevent them from running on changes in this repository

Fixes #212 
