### PR TITLE
fix: use dependencies_file input when diffing

### DIFF
--- a/.github/actions/run-dash/action.yaml
+++ b/.github/actions/run-dash/action.yaml
@@ -79,7 +79,7 @@ runs:
     - name: Check for differences between existing ${{ inputs.dependencies_file }} and the generated one
       id: dependency-diff
       run: |
-        changed=$(git diff DEPENDENCIES)
+        changed=$(git diff ${{ inputs.dependencies_file }})
         if [[ -n "$changed" ]]; then
           echo "${{ inputs.dependencies_file }} not up-to-date"
           echo "changed=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The `run-dash` action is not leveraging the input variable `dependencies_file` to create the git diff that indicates if a dependencies file is out of date or not

Related to #228 