### PR TITLE
chore: tractusx metadata

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,0 +1,6 @@
+product: "sig-infra"
+leadingRepository: "https://github.com/eclipse-tractusx/sig-infra"
+repositories:
+  - name: "sig-infra"
+    usage: "This is the home of Eclipse Tractus-X Special Interest Group (SIG) infra."
+    url: "https://github.com/eclipse-tractusx/sig-infra"

--- a/.tractusx
+++ b/.tractusx
@@ -1,5 +1,6 @@
 product: "sig-infra"
 leadingRepository: "https://github.com/eclipse-tractusx/sig-infra"
+supportingRepository: true
 repositories:
   - name: "sig-infra"
     usage: "This is the home of Eclipse Tractus-X Special Interest Group (SIG) infra."


### PR DESCRIPTION
PR to add .tractusx metadata file with basic configuration + new flag helping identify supporting repository. The flag will be used by quality checks dashboard for better presentation of repositories.