### PR TITLE
chore: add template to request contributor role

### DIFF
--- a/.github/ISSUE_TEMPLATE/support-add-project-contributor.md
+++ b/.github/ISSUE_TEMPLATE/support-add-project-contributor.md
@@ -19,3 +19,5 @@ assignees: ''
 
 Email address to add: <!-- This has to be the email, you use for your Eclipse Foundation account -->
 Committers, that could take over: <!-- Highlight committers you already know or any other with their GitHub handle here in the form of @<github-handle> -->
+
+Please make sure, that you accept the invitation you recieve from GitHub, after you have been added as project contributor.

--- a/.github/ISSUE_TEMPLATE/support-add-project-contributor.md
+++ b/.github/ISSUE_TEMPLATE/support-add-project-contributor.md
@@ -12,7 +12,7 @@ assignees: ''
 >
 > - Make yourself familiar with the Eclipse project roles: https://eclipse-tractusx.github.io/docs/oss/contributor-committer
 > - Make ourself familiar with prerequisites, like a signed ECA: https://eclipse-tractusx.github.io/docs/oss/getting-started
-> - Check the committer liste of our project and higlight at least one of them on this issue, since ever committer
+> - Check the committer list of our project and higlight at least one of them on this issue, since every committer
 > can add project contributors: https://projects.eclipse.org/projects/automotive.tractusx/who
 
 ## Neccessary Information

--- a/.github/ISSUE_TEMPLATE/support-add-project-contributor.md
+++ b/.github/ISSUE_TEMPLATE/support-add-project-contributor.md
@@ -1,0 +1,21 @@
+---
+name: 'Support: Add me as Tractus-X project contributor'
+about: 'Add a user to our Eclipse Foundation project as an official contributor'
+title: 'New Tractus-X project contributor'
+labels: support
+assignees: ''
+---
+
+<!-- This issue template is used to request admission to the Eclipse Tractus-X project contributor group -->
+
+> __Before requesting the project contributor role, please make sure, that you:__
+>
+> - Make yourself familiar with the Eclipse project roles: https://eclipse-tractusx.github.io/docs/oss/contributor-committer
+> - Make ourself familiar with prerequisites, like a signed ECA: https://eclipse-tractusx.github.io/docs/oss/getting-started
+> - Check the committer liste of our project and higlight at least one of them on this issue, since ever committer
+> can add project contributors: https://projects.eclipse.org/projects/automotive.tractusx/who
+
+## Neccessary Information
+
+Email address to add: <!-- This has to be the email, you use for your Eclipse Foundation account -->
+Committers, that could take over: <!-- Highlight committers you already know or any other with their GitHub handle here in the form of @<github-handle> -->


### PR DESCRIPTION
## Description

Recently, there is an increasing number of project contributor role requests. These requests are quite commonly sent to individuals per email.

In order to make the role assignments a bit more transparent and traceable, I am proposing to introduce this topic as support process.

Unlike most of the other support tasks, this one could actually be done by any committer. Since `sig-infra` issues are mostly handled by a single team, I added a hint to highlight any committer, so we do have a chance, that this effort can be spread across multiple shoulders
