### PR TITLE
chore: bump reusable quality check workflow version to 0.8.0

### DIFF
--- a/.github/workflows/reusable-quality-checks.yaml
+++ b/.github/workflows/reusable-quality-checks.yaml
@@ -30,6 +30,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run quality checks
-        uses: eclipse-tractusx/tractusx-quality-checks@v0.7
+        uses: eclipse-tractusx/tractusx-quality-checks@v0.8
         with:
-          version: "0.7.4"
+          version: "0.8.0"


### PR DESCRIPTION
PR to lift reusable quality check workflow to latest 0.8.0 quality checks tool.