### PR TITLE
fix: change reference to reusable quality checks workflow

### DIFF
--- a/.github/workflows/reusable-quality-checks.yaml
+++ b/.github/workflows/reusable-quality-checks.yaml
@@ -30,6 +30,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run quality checks
-        uses: eclipse-tractusx/sig-release@v0.1
+        uses: eclipse-tractusx/sig-release@v1
         with:
-          version: "0.1.0"
+          version: "1.0.0"

--- a/.github/workflows/reusable-quality-checks.yaml
+++ b/.github/workflows/reusable-quality-checks.yaml
@@ -30,6 +30,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run quality checks
-        uses: eclipse-tractusx/tractusx-quality-checks@v0.9
+        uses: eclipse-tractusx/sig-release@v0.1
         with:
-          version: "0.9.0"
+          version: "0.1.0"


### PR DESCRIPTION
PR to change reference to new quality checks reusable workflow at sig-release.

Updates https://github.com/eclipse-tractusx/sig-infra/issues/392