### PR TITLE
chore: update action versions

### DIFF
--- a/.github/workflows/reusable-generate-mermaid-svg.yaml
+++ b/.github/workflows/reusable-generate-mermaid-svg.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
       - name: install mermaid cli
@@ -53,7 +53,7 @@ jobs:
         run: |
           mmdc -V
       - name: checkout source repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: search for files
         id: search_files
         run: |
@@ -70,7 +70,7 @@ jobs:
              echo "${file%.*}.svg"
              echo "generated_files=${file%.*}.svg" >> $GITHUB_OUTPUT
             done
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         # upload generated files as Job artifacts which can be downloaded in the in your caller workflow
         with:
           name: artifacts

--- a/.github/workflows/reusable-generate-puml-svg.yaml
+++ b/.github/workflows/reusable-generate-puml-svg.yaml
@@ -34,7 +34,7 @@ jobs:
       puml-files: ${{ steps.generate.generate.puml_files }}
     steps:
       - name: checkout source repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate PlantUML Diagrams
         id: generate
@@ -43,7 +43,7 @@ jobs:
           format: svg
           pattern: "**/*.puml"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: "**/*.svg"

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ jobs:
     needs: render-images
     steps:
       - name: checkout source repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: download generated svg file from job before
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: artifacts
@@ -106,11 +106,11 @@ jobs:
     needs: render-images
     steps:
       - name: checkout source repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: download generated svg file from job before
         # here you downlowd the generated files from previous job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: artifacts
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run dash
         id: run-dash


### PR DESCRIPTION
## Description

- updated action versions 
- [actions/checkout](https://github.com/actions/checkout/releases)
- [actipns/upload-artifact](https://github.com/actions/upload-artifact/releases)
- [actions/setup-node](https://github.com/actions/setup-node/releases)
- [actions/download-artifacts](https://github.com/actions/download-artifact/releases)

fixes #481 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
