### PR TITLE
feat: add a script to create issues on every org repo

### DIFF
--- a/scripts/create-org-wide-issues/README.md
+++ b/scripts/create-org-wide-issues/README.md
@@ -1,0 +1,31 @@
+# How to create an issue on each repo in `eclipse-tractusx`
+
+This How-To shows an automated approach to create a pre-defined issue on every single repository in
+our `eclipse-tractusx` GitHub organization.
+
+Use cases for such automation could be the tracking of a mandatory change in legal documentation for example.
+
+## Prerequisites
+
+The script described in this how-to is relying on the GitHub CLI (`gh`). See install instructions
+on [cli.github.com](https://cli.github.com/).
+
+## Disclaimer
+
+The [create-org-issues.bash](create-org-issues.bash) script is currently designed to work
+on [eclipse-tractusx](https://github.com/eclipse-tractusx), but can easily be adapted manually to serve different use
+cases.
+At the time of this writing, there have not been any attempts to make the script more flexible, to keep things simple
+and easy to understand.
+
+## Running the script
+
+```shell
+chmod +x ./create-org-issues.bash
+./create-org-issues.bash
+```
+
+It will query all non-archive repositories from [eclipse-tractusx](https://github.com/eclipse-tractusx) and create an
+issue of all of them, with a pre-defined title and body. 
+The title is currently defined in the script directly. As issue body, the contents of [issue-body.md](issue-body.md)
+are used.

--- a/scripts/create-org-wide-issues/create-org-issues.bash
+++ b/scripts/create-org-wide-issues/create-org-issues.bash
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# #############################################################################
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+
+github_host="github.com"
+org="eclipse-tractusx"
+
+issue_title="Mandatory change in licensing and legal documentation"
+issue_body_file="issue-body.md"
+
+readarray -t repos < <(GH_HOST=$github_host gh repo list "$org" --limit 1000 --no-archived --json nameWithOwner --jq '.[].nameWithOwner')
+
+for repo in "${repos[@]}"; do
+    GH_HOST=$github_host gh issue create --title "$issue_title" --body-file "$issue_body_file" --repo "$repo"
+done

--- a/scripts/create-org-wide-issues/issue-body.md
+++ b/scripts/create-org-wide-issues/issue-body.md
@@ -1,0 +1,33 @@
+## Description
+
+Due to a change in how we want to license Eclipse Tractus-X, there are a couple of changes
+to legal documentation in our repositories.
+
+This issue is created for every active repository in our GitHub org, to remind everyone
+about the required changes and also to track the completion of if.
+
+If there are any reasons, why you think this change should not be applied to this repository,
+document them as comment on this issue, before closing it. Be aware, that there are most likely no
+exceptions for our repositories.
+
+If you have any questions, feel free to join the weekly [Community Office Hour](https://eclipse-tractusx.github.io/community/open-meetings#Office%20Hour)
+and raise it there.
+
+## What has to be done?
+
+The following steps have to be completed, to fully implement the licensing change:
+
+- [ ] Add a new file `LICENSE_non-code` in your repository root with the contents of the CC-BY-4.0 license
+- [ ] Remove the `/LICENSES` directory in case you previously stored the CC-BY-4.0 license there. Make sure there is no other CC-BY-4.0 License left, other than on root as `LICENSE_non-code`
+- [ ] Add the "Project Licenses" and "Terms of Use" sections to your `CONTRIBUTING.md` file. See eclipse-tractusx/sig-infra#476 for an example
+- [ ] Adapt "Declared Project License" section in `NOTICE.md`. See eclipse-tractusx/sig-infra#476 for an example
+- [ ] Please verify, your `CONTRIBUTION.md` does not have encoding issues. We found several occurences in repositories.
+
+## Additional information
+
+You can find detailed information in our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release) section 7.
+The changes have been introduces in eclipse-tractusx/eclipse-tractusx.github.io#856.
+
+You can also see an example on how a repository was changed in eclipse-tractusx/sig-infra#476.
+
+Overall progress tracked in eclipse-tractusx/sig-infra#477


### PR DESCRIPTION
## Description

This PR adds a rudimentary script to create a pre-defined issue on every non-archived repo in our GitHub org.
It is planned to be used to track the mandatory change in repo licensing, as soon as this is communicated via mailing list.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
