### PR TITLE
feat: update default dash_version and download URL

### DIFF
--- a/.github/actions/run-dash/action.yaml
+++ b/.github/actions/run-dash/action.yaml
@@ -24,7 +24,7 @@ inputs:
   dash_version:
     description: "The version of `dash-licenses` to install"
     required: true
-    default: "LATEST"
+    default: "v1.1.0"
   dash_input:
     description: "The input dependency list file for `dash-licenses`."
     required: true
@@ -60,7 +60,7 @@ runs:
     - name: Download Dash
       run: |
         echo "Downloading Dash version: ${{ inputs.dash_version }}"
-        curl -L -o dash.jar "https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=${{ inputs.dash_version }}"
+        curl -L -o dash.jar "https://repo.eclipse.org/service/rest/v1/search/assets/download?repository=dash-maven2-releases&maven.groupId=org.eclipse.dash&maven.artifactId=org.eclipse.dash.licenses&maven.baseVersion=${{ inputs.dash_version }}&maven.extension=jar"
       shell: bash
 
     # https://github.com/actions/setup-java

--- a/.github/actions/run-dash/action.yaml
+++ b/.github/actions/run-dash/action.yaml
@@ -1,5 +1,5 @@
 # #############################################################################
-# Copyright (c) 2026 Contributors to the Eclipse Foundation
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/.github/actions/run-dash/action.yaml
+++ b/.github/actions/run-dash/action.yaml
@@ -1,5 +1,5 @@
 # #############################################################################
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ inputs:
   dash_version:
     description: "The version of `dash-licenses` to install"
     required: true
-    default: "v1.1.0"
+    default: "1.1.0"
   dash_input:
     description: "The input dependency list file for `dash-licenses`."
     required: true


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
This pull request updates the `.github/actions/run-dash/action.yaml` workflow to improve the way the `dash-licenses` tool is downloaded and to set a specific default version. The main changes focus on making the workflow more reliable and reproducible.

**Updates to Dash Licenses Tool Downloading:**

* Changed the default `dash_version` from `"LATEST"` to `"v1.1.0"` to ensure a consistent and reproducible version is used in the workflow.
* Updated the `curl` command to use a new download URL format for fetching the `dash-licenses` JAR, aligning with the latest repository structure and improving reliability.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
