### PR TITLE
chore: pin GitHub Actions workflows to immutable SHA digests

### DIFF
--- a/.github/workflows/generate-kit-pdf.yaml
+++ b/.github/workflows/generate-kit-pdf.yaml
@@ -39,10 +39,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
       
@@ -66,7 +66,7 @@ jobs:
           python scripts/generate_kit_pdf.py
       
       - name: Upload PDF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: kit-template-pdf
           path: kit-template.pdf

--- a/.github/workflows/inform-team-about-new-issue.yaml
+++ b/.github/workflows/inform-team-about-new-issue.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Add comment
         # MIT Licence from https://github.com/peter-evans/create-or-update-comment/blob/main/LICENSE
-        uses: peter-evans/create-or-update-comment@v2.1.1
+        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2.1.1
         with:
           issue-number: ${{ github.event.issue.number }}
           # Here you can add you personal style of comment messages and which GitHub-team should be informed
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Add comment
         # MIT Licence from https://github.com/peter-evans/create-or-update-comment/blob/main/LICENSE
-        uses: peter-evans/create-or-update-comment@v2.1.1
+        uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2.1.1
         with:
           issue-number: ${{ github.event.issue.number }}
           # Here you can add you personal style of comment messages

--- a/.github/workflows/reusable-dependencies-dotnet.yaml
+++ b/.github/workflows/reusable-dependencies-dotnet.yaml
@@ -33,18 +33,18 @@ jobs:
     steps:
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@8e6bd2905eef86446227f003dda1deb3916c4aaf # v2
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install dependencies
         run: dotnet restore src
@@ -78,7 +78,7 @@ jobs:
         if: steps.dependencies-changed.outputs.changed == 'true'
 
       - name: Upload DEPENDENCIES file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           path: DEPENDENCIES
         if: steps.dependencies-changed.outputs.changed == 'true'

--- a/.github/workflows/reusable-dependencies-yarn.yaml
+++ b/.github/workflows/reusable-dependencies-yarn.yaml
@@ -30,13 +30,13 @@ jobs:
     steps:
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       # For this step to work, you need to provide the executable of dash tool in the './scripts/download' directory (make sure to regularly update the executable)
       - name: Generate Dependencies file
@@ -64,7 +64,7 @@ jobs:
         if: steps.dependencies-changed.outputs.changed == 'true'
 
       - name: Upload DEPENDENCIES file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           path: DEPENDENCIES
         if: steps.dependencies-changed.outputs.changed == 'true'

--- a/.github/workflows/reusable-generate-mermaid-svg.yaml
+++ b/.github/workflows/reusable-generate-mermaid-svg.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ inputs.node_version }}
       - name: install mermaid cli
@@ -53,7 +53,7 @@ jobs:
         run: |
           mmdc -V
       - name: checkout source repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: search for files
         id: search_files
         run: |
@@ -70,7 +70,7 @@ jobs:
              echo "${file%.*}.svg"
              echo "generated_files=${file%.*}.svg" >> $GITHUB_OUTPUT
             done
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         # upload generated files as Job artifacts which can be downloaded in the in your caller workflow
         with:
           name: artifacts

--- a/.github/workflows/reusable-generate-puml-svg.yaml
+++ b/.github/workflows/reusable-generate-puml-svg.yaml
@@ -34,16 +34,16 @@ jobs:
       puml-files: ${{ steps.generate.generate.puml_files }}
     steps:
       - name: checkout source repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Generate PlantUML Diagrams
         id: generate
-        uses: rotaract/plantuml-action@v1.3.0
+        uses: rotaract/plantuml-action@3eb86e193fd5b03e72f49f49bdecf4d2dbf46944 # v1.3.0
         with:
           format: svg
           pattern: "**/*.puml"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: artifacts
           path: "**/*.svg"

--- a/.github/workflows/reusable-quality-checks.yaml
+++ b/.github/workflows/reusable-quality-checks.yaml
@@ -27,9 +27,9 @@ jobs:
     name: Check quality guidelines
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Run quality checks
-        uses: eclipse-tractusx/sig-release@v1
+        uses: eclipse-tractusx/sig-release@1e0d9e2888e1159223566f154acc32f736e30c9f # v1
         with:
           version: "1.3.1"


### PR DESCRIPTION
### Context
This pull request is part of the security hardening initiative for the `eclipse-tractusx` organization. The goal is to replace mutable GitHub Action version tags with immutable commit SHAs across all non-archived repositories.

### Changes
- Pinned `actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, `peter-evans/create-or-update-comment`, `actions/setup-java`, `actions/setup-dotnet`, `actions/setup-node`, `rotaract/plantuml-action`, and `eclipse-tractusx/sig-release` to immutable commit SHAs across 7 workflow files.

### Verification
- Audited all workflow files in the `sig-infra` repository.
- Resolved each mutable tag to its corresponding commit SHA using the GitHub API.
- Applied the updates to the following files:
    - `.github/workflows/generate-kit-pdf.yaml`
    - `.github/workflows/inform-team-about-new-issue.yaml`
    - `.github/workflows/reusable-dependencies-dotnet.yaml`
    - `.github/workflows/reusable-dependencies-yarn.yaml`
    - `.github/workflows/reusable-generate-mermaid-svg.yaml`
    - `.github/workflows/reusable-generate-puml-svg.yaml`
    - `.github/workflows/reusable-quality-checks.yaml`